### PR TITLE
feat: add support for insecure TLS connections

### DIFF
--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -12,7 +12,7 @@ func TestParseJobPath(t *testing.T) {
 		Username: "appleboy",
 		Token:    "1234",
 	}
-	jenkins := NewJenkins(auth, "http://example.com")
+	jenkins := NewJenkins(auth, "http://example.com", false)
 
 	assert.Equal(t, "/job/foo", jenkins.parseJobPath("/foo/"))
 	assert.Equal(t, "/job/foo", jenkins.parseJobPath("foo/"))
@@ -25,7 +25,7 @@ func TestUnSupportProtocol(t *testing.T) {
 		Username: "foo",
 		Token:    "bar",
 	}
-	jenkins := NewJenkins(auth, "example.com")
+	jenkins := NewJenkins(auth, "example.com", false)
 
 	err := jenkins.trigger("drone-jenkins", nil)
 	assert.NotNil(t, err)
@@ -36,7 +36,7 @@ func TestTriggerBuild(t *testing.T) {
 		Username: "foo",
 		Token:    "bar",
 	}
-	jenkins := NewJenkins(auth, "http://example.com")
+	jenkins := NewJenkins(auth, "http://example.com", false)
 
 	err := jenkins.trigger("drone-jenkins", url.Values{"token": []string{"bar"}})
 	assert.Nil(t, err)

--- a/main.go
+++ b/main.go
@@ -54,6 +54,11 @@ func main() {
 			Usage:  "jenkins job",
 			EnvVar: "PLUGIN_JOB,JENKINS_JOB,INPUT_JOB",
 		},
+		cli.BoolFlag{
+			Name:   "insecure",
+			Usage:  "allow insecure server connections when using SSL",
+			EnvVar: "PLUGIN_INSECURE,JENKINS_INSECURE,INPUT_INSECURE",
+		},
 	}
 
 	// Override a template
@@ -100,6 +105,7 @@ func run(c *cli.Context) error {
 		Username: c.String("user"),
 		Token:    c.String("token"),
 		Job:      c.StringSlice("job"),
+		Insecure: c.Bool("insecure"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -12,6 +12,7 @@ type (
 		Username string
 		Token    string
 		Job      []string
+		Insecure bool
 	}
 )
 
@@ -46,7 +47,7 @@ func (p Plugin) Exec() error {
 		Token:    p.Token,
 	}
 
-	jenkins := NewJenkins(auth, p.BaseURL)
+	jenkins := NewJenkins(auth, p.BaseURL, p.Insecure)
 
 	for _, v := range jobs {
 		if err := jenkins.trigger(v, nil); err != nil {


### PR DESCRIPTION
- Add `crypto/tls` import in `jenkins.go`
- Add `Client` field to `Jenkins` struct
- Modify `NewJenkins` function to accept an `insecure` parameter and configure HTTP client accordingly
- Update `sendRequest` method to use the `Client` field from the `Jenkins` struct
- Update tests in `jenkins_test.go` to include the `insecure` parameter in `NewJenkins` calls
- Add `insecure` flag to CLI options in `main.go`
- Add `Insecure` field to `Plugin` struct
- Update `Plugin.Exec` method to pass `Insecure` field to `NewJenkins`