### PR TITLE
Fix jenkins.go false negative result when triggering Jenkins job.

### DIFF
--- a/jenkins.go
+++ b/jenkins.go
@@ -92,7 +92,7 @@ func (jenkins *Jenkins) post(path string, params url.Values, body interface{}) (
 		return
 	}
 
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected response code: %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
When triggering a Jenkins job, Jenkins API call returns 200 OK but drone-jenkins expects 201.  So, the trigger succeeded but drone-jenkins returns false negative.

The Jenkins version I am using to test this is 2.346.3

The way in which drone-jenkins is used is via the jenkins-action:

https://github.com/appleboy/jenkins-action/blob/master/entrypoint.sh