### PR TITLE
feat: add CSRF crumb and session support to Jenkins client

### DIFF
--- a/jenkins_test.go
+++ b/jenkins_test.go
@@ -751,6 +751,8 @@ func TestNewJenkinsWithCACert(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		assert.NotNil(t, jenkins)
-		assert.Equal(t, http.DefaultClient, jenkins.Client)
+		assert.NotNil(t, jenkins.Client)
+		// Client should have CookieJar for CSRF session management
+		assert.NotNil(t, jenkins.Client.Jar)
 	})
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -314,7 +314,10 @@ func TestExecTriggerMultipleJobs(t *testing.T) {
 	// Create a mock Jenkins server
 	jobsTriggered := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jobsTriggered++
+		// Only count POST requests (job triggers), not GET requests (crumb)
+		if r.Method == "POST" {
+			jobsTriggered++
+		}
 		w.Header().
 			Set("Location", fmt.Sprintf("http://jenkins.example.com/queue/item/%d/", jobsTriggered))
 		w.WriteHeader(http.StatusCreated)
@@ -390,7 +393,10 @@ func TestExecWithJobsContainingWhitespace(t *testing.T) {
 	// Create a mock Jenkins server
 	jobsTriggered := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jobsTriggered++
+		// Only count POST requests (job triggers), not GET requests (crumb)
+		if r.Method == "POST" {
+			jobsTriggered++
+		}
 		w.Header().
 			Set("Location", fmt.Sprintf("http://jenkins.example.com/queue/item/%d/", jobsTriggered))
 		w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
- Add support for Jenkins CSRF protection by managing and adding CSRF crumb to POST requests
- Store and cache CSRF crumb after fetching from Jenkins for session reuse
- Use an HTTP client with CookieJar for session management to support CSRF crumb handling
- Update existing tests to check for presence of CookieJar in the HTTP client
- Improve test servers to only count job trigger POSTs, ignoring GET requests for crumbs

fix https://github.com/appleboy/drone-jenkins/pull/48